### PR TITLE
ci: Pages 배포 액션 버전 업그레이드

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 요약
deprecated된 `actions/upload-artifact@v3` 의존성으로 인해 GitHub Pages 배포가 자동 실패하던 문제를 해결합니다. `static.yml`의 액션 버전을 최신으로 업그레이드합니다.

## 변경 사항
- `actions/checkout` v3 → v4
- `actions/configure-pages` v2 → v5
- `actions/upload-pages-artifact` v1 → v3 (deprecated된 `upload-artifact@v3` 전이 의존성 제거 — 핵심 수정)
- `actions/deploy-pages` v1 → v4

## 관련 이슈
Closes #2

## 테스트 체크리스트
- [ ] `main` 푸시 시 "Deploy static content to Pages" 워크플로우가 성공으로 완료되는지 확인
- [ ] 실패 로그의 `deprecated version of actions/upload-artifact: v3` 에러가 더 이상 발생하지 않는지 확인
- [ ] `docs/` 내용이 라이브 사이트(GitHub Pages)에 정상 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)